### PR TITLE
Redraw screen after opening haddock browser

### DIFF
--- a/ftplugin/haskell_doc.vim
+++ b/ftplugin/haskell_doc.vim
@@ -183,6 +183,7 @@ function! DocBrowser(url)
   else
     silent exe '!'.printf(g:haddock_browser_callformat,g:haddock_browser,escape(url,'#%')) 
   endif
+  redraw!
 endfunction
 
 "Doc/Doct are an old interface for documentation lookup


### PR DESCRIPTION
In Vim terminal mode (tested on Mac only), screen would go blank after
haddock browser window/tab is opened. This forces Vim to refresh the
screen.
