### PR TITLE
Add options to turn off haskellmode's completion.

### DIFF
--- a/compiler/ghc.vim
+++ b/compiler/ghc.vim
@@ -382,7 +382,14 @@ function! GHC_CompleteImports(findstart, base)
     return res
   endif
 endfunction
-set omnifunc=GHC_CompleteImports
+
+if !exists("g:haskellmode_completion_ghc")
+  let g:haskellmode_completion_ghc = 1
+endif
+
+if g:haskellmode_completion_ghc != 0
+    set omnifunc=GHC_CompleteImports
+endif
 "
 " Vim's default completeopt is menu,preview
 " you probably want at least menu, or you won't see alternatives listed

--- a/doc/haskellmode.txt
+++ b/doc/haskellmode.txt
@@ -167,7 +167,7 @@ CONTENTS                                                         *haskellmode*
     liking, you probably won't need to do any fine tuning.
 
                                                 *g:haddock_browser_callformat*
-    By default, the web browser|g:haddock_browser| will be started
+    By default, the web browser |g:haddock_browser| will be started
     asynchronously (in the background) on Windows or when vim is running in a
     GUI, and synchronously (in the foreground) otherwise. These settings seem
     to work fine if you are using a console mode browser (eg, when editing in
@@ -216,6 +216,15 @@ CONTENTS                                                         *haskellmode*
     is in your PATH):
 >
         :let g:wget="C:\Program Files\wget\wget.exe"
+<
+                                                    *g:haskellmode_completion*
+    By default, haskellmode sets omnifunc and completefunc to a GHC-based
+    completion of imported symbols and completion from Haddock, respectively.
+    If you want to turn these off (e.g. if you're using necoghc or an
+    autocomplete system like YCM or neocomplete), use:
+>
+       :let g:haskellmode_completion_ghc=0
+       :let g:haskellmode_completion_haddock=0
 <
 
     Finally, the mappings actually use|<LocalLeader>|behind the scenes, so if

--- a/ftplugin/haskell_doc.vim
+++ b/ftplugin/haskell_doc.vim
@@ -756,8 +756,15 @@ function! CompleteHaddock(findstart, base)
     return res
   endif
 endfunction
-setlocal completefunc=CompleteHaddock
-"
+
+if !exists("g:haskellmode_completion_haddock")
+  let g:haskellmode_completion_haddock = 1
+endif
+
+if g:haskellmode_completion_haddock != 0
+    set completefunc=CompleteHaddock
+endif
+
 " Vim's default completeopt is menu,preview
 " you probably want at least menu, or you won't see alternatives listed
 " setlocal completeopt+=menu


### PR DESCRIPTION
This patch adds options for turning off haskellmode's completion since it currently tramples over the omnifunc (with GHC_CompleteImports) and completefunc (with CompleteHaddock), regardless of whether it is already set. This is a problem if the user wants to set omnifunc/completefunc to something else (e.g. if the user is using necoghc or an autocompletion system like YCM or neocomplete). The names of the added options are `g:haskellmode_completion_ghc` and `g:haskellmode_completion_haddock`.
